### PR TITLE
Fixed reference to Config repo in `deps.ts`

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,8 +1,8 @@
 //export { serve } from "https://deno.land/std@0.201.0/http/server.ts";
 export { join } from "https://deno.land/std@0.201.0/path/mod.ts";
-export * from "https://deno.land/std@0.201.0/http/file_server.ts"
+export * from "https://deno.land/std@0.201.0/http/file_server.ts";
 export { debounce } from "https://deno.land/std@0.201.0/async/debounce.ts";
 export * as esbuild from "https://deno.land/x/esbuild@v0.17.11/mod.js";
 export { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.6.0/mod.ts";
-export * from "https://raw.githubusercontent.com/nhrones/Browser/master/browser.ts"
-export * from "../Config/mod.ts"
+export * from "https://raw.githubusercontent.com/nhrones/Browser/master/browser.ts";
+export * from "https://raw.githubusercontent.com/nhrones/Config/main/mod.ts";


### PR DESCRIPTION
Modified last import in `deps.ts` to point to a GitHub URL instead of a relative file path to another (Config) repo.